### PR TITLE
Closed connection detection when in socket_loop

### DIFF
--- a/src/misultin_http.erl
+++ b/src/misultin_http.erl
@@ -348,10 +348,10 @@ socket_loop(#c{sock = Sock, socket_mode = SocketMode, compress = Compress} = C, 
 		{'DOWN', _Ref, process, LoopPid, _Reason} ->
 			?LOG_ERROR("error in custom loop: ~p serving request: ~p", [_Reason, Request]),
 			misultin_socket:send(Sock, build_error_message(500, Request), SocketMode);
-        {tcp_closed, _Port} ->
+        {tcp_closed, Sock} ->
             ?LOG_WARNING("tcp connection was closed",[]),
             ok;
-        {ssl_closed, _Port} ->
+        {ssl_closed, Sock} ->
             ?LOG_WARNING("ssl connection was closed",[]),
             ok;
 		_Else ->

--- a/src/misultin_http.erl
+++ b/src/misultin_http.erl
@@ -353,10 +353,7 @@ socket_loop(#c{sock = Sock, socket_mode = SocketMode, compress = Compress} = C, 
             ok;
         {ssl_closed, Sock} ->
             ?LOG_WARNING("ssl connection was closed",[]),
-            ok;
-		_Else ->
-			?LOG_DEBUG("unknown message received: ~p, ignoring", [_Else]),
-			socket_loop(C, Request, LoopPid)
+            ok
 	end.
 
 % Description: Ensure Body is binary.

--- a/src/misultin_http.erl
+++ b/src/misultin_http.erl
@@ -351,6 +351,9 @@ socket_loop(#c{sock = Sock, socket_mode = SocketMode, compress = Compress} = C, 
         {tcp_closed, _Port} ->
             ?LOG_WARNING("tcp connection was closed",[]),
             ok;
+        {ssl_closed, _Port} ->
+            ?LOG_WARNING("ssl connection was closed",[]),
+            ok;
 		_Else ->
 			?LOG_DEBUG("unknown message received: ~p, ignoring", [_Else]),
 			socket_loop(C, Request, LoopPid)

--- a/src/misultin_http.erl
+++ b/src/misultin_http.erl
@@ -295,7 +295,7 @@ call_mfa(#c{loop = Loop} = C, Request) ->
 
 % socket loop
 socket_loop(#c{sock = Sock, socket_mode = SocketMode, compress = Compress} = C, #req{headers = RequestHeaders} = Request, LoopPid) ->
-	misultin_socket:setopts(Sock, [{active, once}], SocketMode),
+	misultin_socket:setopts(Sock, [{active, once},{packet, http}], SocketMode),
 	% receive
 	receive
 		{stream_head, HttpCode, Headers0} ->

--- a/src/misultin_http.erl
+++ b/src/misultin_http.erl
@@ -295,6 +295,7 @@ call_mfa(#c{loop = Loop} = C, Request) ->
 
 % socket loop
 socket_loop(#c{sock = Sock, socket_mode = SocketMode, compress = Compress} = C, #req{headers = RequestHeaders} = Request, LoopPid) ->
+	misultin_socket:setopts(Sock, [{active, once}], SocketMode),
 	% receive
 	receive
 		{stream_head, HttpCode, Headers0} ->
@@ -347,6 +348,9 @@ socket_loop(#c{sock = Sock, socket_mode = SocketMode, compress = Compress} = C, 
 		{'DOWN', _Ref, process, LoopPid, _Reason} ->
 			?LOG_ERROR("error in custom loop: ~p serving request: ~p", [_Reason, Request]),
 			misultin_socket:send(Sock, build_error_message(500, Request), SocketMode);
+        {tcp_closed, _Port} ->
+            ?LOG_WARNING("tcp connection was closed",[]),
+            ok;
 		_Else ->
 			?LOG_DEBUG("unknown message received: ~p, ignoring", [_Else]),
 			socket_loop(C, Request, LoopPid)


### PR DESCRIPTION
We needed this so that when we're in keepalive mode we can instantaneously detect that the client is gone
