### PR TITLE
Chunked encoding support

### DIFF
--- a/src/misultin_req.erl
+++ b/src/misultin_req.erl
@@ -123,6 +123,8 @@ stream(head) ->
 	stream(head, 200, []);
 stream({error, Reason}) ->
 	SocketPid ! {stream_error, Reason};
+stream({chunk, Data}) ->
+    stream(integer_to_list(length(Data), 16) ++ "\r\n" ++ Data ++ "\r\n");
 stream(Data) ->
 	catch SocketPid ! {stream_data, Data}.
 stream(head, Headers) ->


### PR DESCRIPTION
There are applications that use Transfer-Encoding: chunked and since it is a part of http://tools.ietf.org/html/rfc2616 it would make sense to have this in misultin rather than implemented manually in all those applications
