### PR TITLE
Error when close page with opened websocket in firefox 4

### DIFF
--- a/src/misultin_websocket.erl
+++ b/src/misultin_websocket.erl
@@ -226,6 +226,9 @@ handle_data(none, [0|T], Socket, WsHandleLoopPid, SocketMode, WsAutoExit) ->
 	handle_data([], T, Socket, WsHandleLoopPid, SocketMode, WsAutoExit);
 handle_data(none, [], Socket, WsHandleLoopPid, SocketMode, WsAutoExit) ->
 	ws_loop(Socket, none, WsHandleLoopPid, SocketMode, WsAutoExit);
+handle_data(none, [255|T], Socket, WsHandleLoopPid, SocketMode, WsAutoExit) ->
+       websocket_close(Socket, WsHandleLoopPid, SocketMode, WsAutoExit),
+       handle_data(none, T, Socket, WsHandleLoopPid, SocketMode, WsAutoExit);
 handle_data(L, [255|T], Socket, WsHandleLoopPid, SocketMode, WsAutoExit) ->
 	WsHandleLoopPid ! {browser, lists:reverse(L)},
 	handle_data(none, T, Socket, WsHandleLoopPid, SocketMode, WsAutoExit);


### PR DESCRIPTION
```
=ERROR REPORT==== 25-Mar-2011::16:21:24 ===
Error in process <0.85.0> on node 'amq_client@cbr_work' with exit value: {function_clause, [{lists,reverse,[none]},{misultin_websocket,handle_data,6},{misultin_http,handle_data,8}]}


=ERROR REPORT==== 25-Mar-2011::16:21:24 ===
        module: misultin
        line: 290
http process <0.85.0> has died with reason: {function_clause,
                                             [{lists,reverse,[none]},
                                              {misultin_websocket,
                                               handle_data,6},
                                              {misultin_http,handle_data,8}]}, removing from references of open connections
```
