### PR TITLE
Minor Helpful Changes

### DIFF
--- a/src/misultin.erl
+++ b/src/misultin.erl
@@ -352,6 +352,8 @@ code_change(_OldVsn, State, _Extra) ->
 
 % Function: -> false | IpTuple
 % Description: Checks and converts a string Ip to inet repr.
+check_and_convert_string_to_ip({_, _, _, _} = Ip) ->
+    Ip;
 check_and_convert_string_to_ip(Ip) ->
 	case inet_parse:address(Ip) of
 		{error, _Reason} ->
@@ -362,6 +364,8 @@ check_and_convert_string_to_ip(Ip) ->
 	
 % Function: -> true | false
 % Description: Checks if all necessary Ssl Options have been specified
+check_ssl_options(false) ->
+    true;
 check_ssl_options(SslOptions) ->
 	Opts = [verify, fail_if_no_peer_cert, verify_fun, depth, certfile, keyfile, password, cacertfile, ciphers, reuse_sessions, reuse_session],
 	F = fun({Name, _Value}) ->

--- a/src/misultin_req.erl
+++ b/src/misultin_req.erl
@@ -80,6 +80,9 @@ get(method) ->
 	Req#req.method;
 get(uri) ->
 	Req#req.uri;
+get(str_uri) ->
+    {_UriType, RawUri} = Req#req.uri,
+    unquote(RawUri);
 get(args) ->
 	Req#req.args;
 get(headers) ->


### PR DESCRIPTION
Changes:
Allow the ssl and ip options to be specified in the same format as the default value.
Add the str_uri case to the get/1 method in the request.

Thank you for adding the {name, false} option, that has been a problem for awhile.  These are changes I have found useful in the past.

Thanks,
Michael
