### PR TITLE
Use iolist_size for chunks instead of length

### DIFF
--- a/src/misultin_req.erl
+++ b/src/misultin_req.erl
@@ -137,7 +137,7 @@ chunk(head) ->
 chunk(done) ->
 	stream("0\r\n\r\n");
 chunk(Template) ->
-	stream([erlang:integer_to_list(length(Template), 16), "\r\n", Template, "\r\n"]).
+	stream([erlang:integer_to_list(iolist_size(Template), 16), "\r\n", Template, "\r\n"]).
 chunk(head, Headers) ->
 	% add Transfer-Encoding chunked header if needed
 	Headers0 = case misultin_utility:header_get_value('Transfer-Encoding', Headers) of


### PR DESCRIPTION
Allows client to send iolists directly to chunk without having to
convert to a list first.

I put this in a branch off 0.7, since it looks like master is in flux right now (chunked example doesn't work, api has changed slightly i think)
