### PR TITLE
Allow `binary` tags in headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/src/misultin_http.erl
+++ b/src/misultin_http.erl
@@ -553,6 +553,8 @@ connection_str(close) -> "Close".
 % Description: Encode headers
 enc_headers([{Tag, Val}|T]) when is_atom(Tag) ->
 	[atom_to_list(Tag), ": ", enc_header_val(Val), "\r\n"|enc_headers(T)];
+enc_headers([{Tag, Val}|T]) when is_binary(Tag) ->
+	[binary_to_list(Tag), ": ", enc_header_val(Val), "\r\n"|enc_headers(T)];
 enc_headers([{Tag, Val}|T]) when is_list(Tag) ->
 	[Tag, ": ", enc_header_val(Val), "\r\n"|enc_headers(T)];
 enc_headers([]) ->


### PR DESCRIPTION
It's very handy if header tags holds in cache. For example, rendered template and `ETag`.
