### PR TITLE
Build with rebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,27 +5,25 @@ INCLUDE_DIR := include
 ERLC := erlc
 ERLC_FLAGS := -W -I $(INCLUDE_DIR) -o $(EBIN_DIR)
 
-all:
-	@mkdir -p $(EBIN_DIR)
-	$(ERLC) $(ERLC_FLAGS) $(SRC_DIR)/*.erl
-	@cp $(SRC_DIR)/misultin.app.src $(EBIN_DIR)/misultin.app
-	
-clean:
-	@rm -rf $(EBIN_DIR)/*
-	@rm -f erl_crash.dump
-	
-debug:
-	@mkdir -p $(EBIN_DIR)
-	$(ERLC) -D log_debug $(ERLC_FLAGS) $(SRC_DIR)/*.erl
-	@cp $(SRC_DIR)/misultin.app.src $(EBIN_DIR)/misultin.app
-	
-dialyzer:
-	@mkdir -p $(EBIN_DIR)
-	$(ERLC) +debug_info $(ERLC_FLAGS) $(SRC_DIR)/*.erl
-	@cp $(SRC_DIR)/misultin.app.src $(EBIN_DIR)/misultin.app
+all: compile
 
-example:
-	@mkdir -p $(EBIN_DIR)
-	$(ERLC) $(ERLC_FLAGS) $(SRC_DIR)/*.erl
-	@cp $(SRC_DIR)/misultin.app.src $(EBIN_DIR)/misultin.app
+clean:
+	@rebar clean
+
+compile:
+	@rebar compile
+
+debug: 
+	@rebar debug_info=true compile
+
+dialyzer: check-plt
+	@rebar dialyze
+
+check-plt: compile
+	@rebar check-plt
+
+build-plt: compile
+	@rebar build-plt
+
+example: compile
 	$(ERLC) $(ERLC_FLAGS) $(EXAMPLES_DIR)/*.erl


### PR DESCRIPTION
Converts most of the Makefile to use rebar for the build.  It assumes rebar is in $PATH (not bundled).
