### PR TITLE
Additional clause for misultin_websocket:handle_data

### DIFF
--- a/src/misultin_websocket.erl
+++ b/src/misultin_websocket.erl
@@ -250,7 +250,13 @@ handle_data(L, [255|T], Socket, WsHandleLoopPid, SocketMode, WsAutoExit, ServerR
 handle_data(L, [H|T], Socket, WsHandleLoopPid, SocketMode, WsAutoExit, ServerRef) ->
 	handle_data([H|L], T, Socket, WsHandleLoopPid, SocketMode, WsAutoExit, ServerRef);
 handle_data([], L, Socket, WsHandleLoopPid, SocketMode, WsAutoExit, ServerRef) ->
+	ws_loop(ServerRef, Socket, L, WsHandleLoopPid, SocketMode, WsAutoExit);
+handle_data(L, [], Socket, WsHandleLoopPid, SocketMode, WsAutoExit, ServerRef) ->
 	ws_loop(ServerRef, Socket, L, WsHandleLoopPid, SocketMode, WsAutoExit).
+
+
+
+
 
 % Close socket and custom handling loop dependency
 websocket_close(ServerRef, Socket, WsHandleLoopPid, SocketMode, WsAutoExit) ->


### PR DESCRIPTION
Hi,

when using your websocket implementation with chrome I got the following error from time to time:

```
=ERROR REPORT==== 19-May-2011::10:12:41 ===
        module: misultin
        line: 306
http process <0.149.0> has died with reason: 
  {function_clause,
    [{misultin_websocket,
      handle_data,
      [
        "some string",
        [],
        #Port<0.3462>,
        <0.150.0>,
        http,
        false,
        <0.55.0>
      ]},
     {misultin_http,handle_data,9}
    ]
  }, removing from references of open connections
```

The additional clause that I added to your code fixed this.
To be honest, I do not completely understand if my fix is perfect or if it is just a workaround.

Thanks for your great work.
Heiner
