### PR TITLE
Please export function to get tid of TablePidsWs

### DIFF
--- a/src/misultin_server.erl
+++ b/src/misultin_server.erl
@@ -39,7 +39,7 @@
 
 % API
 -export([start_link/1]).
--export([http_pid_ref_add/2, http_pid_ref_remove/3, ws_pid_ref_add/2, ws_pid_ref_remove/2, get_rfc_date/1, get_table_date_ref/1]).
+-export([http_pid_ref_add/2, http_pid_ref_remove/3, ws_pid_ref_add/2, ws_pid_ref_remove/2, get_rfc_date/1, get_table_date_ref/1, get_table_pids_ws_ref/1]).
 
 % macros
 -define(TABLE_PIDS_HTTP, misultin_table_pids_http).

--- a/src/misultin_server.erl
+++ b/src/misultin_server.erl
@@ -96,6 +96,11 @@ get_rfc_date(TableDateRef) ->
 -spec get_table_date_ref(ServerRef::pid()) -> TableDateRef::ets:tid().
 get_table_date_ref(ServerRef) ->
 	gen_server:call(ServerRef, get_table_date_ref).
+
+% Retrieve table pids_ws reference
+-spec get_table_pids_ws_ref(ServerRef::pid()) -> TablePidsWs::ets:tid().
+get_table_pids_ws_ref(ServerRef) ->
+  gen_server:call(ServerRef, get_table_pids_ws_ref).
 	
 % ============================ /\ API ======================================================================
 
@@ -156,6 +161,10 @@ handle_call({http_pid_ref_add, HttpPid}, _From, #state{max_connections = MaxConn
 % get table date reference
 handle_call(get_table_date_ref, _From, #state{table_date = TableDate} = State) ->
 	{reply, TableDate, State};
+
+% get table pids ws reference
+handle_call(get_table_pids_ws_ref, _From, #state{table_pids_ws = TablePidsWs} = State) ->
+  {reply, TablePidsWs, State};
 
 % handle_call generic fallback
 handle_call(_Request, _From, State) ->


### PR DESCRIPTION
Added a function (get_table_pids_ws/1) to misultin_server.erl that can be used to get tid of TablePidsWs.
Can be used to query table for number of websockets open or even broadcast a message to all of them.
