### PR TITLE
Fix for hybi-10 on large messages where tcp fragmentation was causing false positive frame matches

### DIFF
--- a/src/misultin_websocket.erl
+++ b/src/misultin_websocket.erl
@@ -170,8 +170,8 @@ ws_loop(WsHandleLoopPid, #ws{vsn = Vsn, socket = Socket, socket_mode = SocketMod
 			case VsnMod:handle_data(Data, State, {Socket, SocketMode, WsHandleLoopPid}) of
 				websocket_close ->
 					misultin_websocket:websocket_close(Socket, WsHandleLoopPid, SocketMode, WsAutoExit);
-				{websocket_close, Data} ->
-					misultin_socket:send(Socket, Data, SocketMode),
+				{websocket_close, CloseData} ->
+					misultin_socket:send(Socket, CloseData, SocketMode),
 					misultin_websocket:websocket_close(Socket, WsHandleLoopPid, SocketMode, WsAutoExit);
 				NewState ->
 					ws_loop(WsHandleLoopPid, Ws, NewState)


### PR DESCRIPTION
hybi-10 was randomly failing when tcp fragmentation happened due to secondary passes through i_handle_data
some times accidentally matching the remaining payload as a valid header.
This caused a corrupt read and subsequent crash of the socket process.

also fixed is the handling of {websocket_close,Data}, was re-using an already bound variable (Data) causing a pattern
match fail in cases where the websocket module was trying to close a socket.

Changed to use a new CloseData variable to allow the match to happen and the response to be sent
