### PR TITLE
fix for websockets when behind stunnel

### DIFF
--- a/include/misultin.hrl
+++ b/include/misultin.hrl
@@ -149,7 +149,8 @@
 	ws_loop				= undefined :: undefined | function(),			% the loop handling websockets
 	ws_autoexit			= true :: boolean(),							% shoud the ws process be automatically killed?
 	ws_versions			= undefined :: [websocket_version()],			% list of supported ws versions
-	access_log			= undefined :: undefined | function()			% access log function
+	access_log			= undefined :: undefined | function(),			% access log function
+	external_ssl		= false :: boolean()							% if we are deployed behind stunnel, or other ssl proxy
 }).
 
 % Request
@@ -166,7 +167,8 @@
 	uri				= undefined :: undefined | http_uri(),
 	args			= "" :: list(),									% Part of URI after ?
 	headers			= [] :: http_headers(),
-	body			= <<>> :: binary()
+	body			= <<>> :: binary(),
+	external_ssl	= false :: boolean()							% if we are deployed behind stunnel, or other ssl proxy
 }).
 
 % Websocket Request

--- a/src/misultin.erl
+++ b/src/misultin.erl
@@ -105,6 +105,7 @@ init([Options]) ->
 		{recv_timeout, 30*1000, fun is_non_neg_integer/1, recv_timeout_not_integer},
 		{max_connections, 4096, fun is_non_neg_integer/1, invalid_max_connections_option},
 		{ssl, false, fun check_ssl_options/1, invalid_ssl_options},
+		{external_ssl, false, fun is_boolean/1, invalid_ssl_external},
 		{recbuf, default, fun check_recbuf/1, recbuf_not_integer},
 		% misultin
 		{post_max_size, 4*1024*1024, fun is_non_neg_integer/1, invalid_post_max_size_option},		% defaults to 4 MB
@@ -130,6 +131,7 @@ init([Options]) ->
 			RecvTimeout = proplists:get_value(recv_timeout, OptionsVerified),
 			MaxConnections = proplists:get_value(max_connections, OptionsVerified),
 			SslOptions0 = proplists:get_value(ssl, OptionsVerified),
+			ExternalSsl = proplists:get_value(external_ssl, OptionsVerified),
 			% misultin options
 			PostMaxSize = proplists:get_value(post_max_size, OptionsVerified),
 			GetUrlMaxSize = proplists:get_value(get_url_max_size, OptionsVerified),
@@ -194,7 +196,8 @@ init([Options]) ->
 						ws_loop = WsLoop,
 						ws_autoexit = WsAutoExit,
 						ws_versions = WsVersions,
-						access_log = AccessLogFun
+						access_log = AccessLogFun,
+						external_ssl = ExternalSsl
 					},
 					% define misultin_server supervisor specs
 					ServerSpec = {server, {misultin_server, start_link, [{MaxConnections}]}, permanent, 60000, worker, [misultin_server]},

--- a/src/misultin_http.erl
+++ b/src/misultin_http.erl
@@ -56,7 +56,8 @@
 	ws_loop				= undefined :: undefined | function(),
 	ws_autoexit			= true :: boolean(),
 	ws_versions			= undefined :: [websocket_version()],
-	access_log			= undefined :: undefined | function()
+	access_log			= undefined :: undefined | function(),
+	external_ssl		= false :: boolean()
 }).
 -record(req_options, {
 	comet				= false :: boolean()		% if comet =:= true, we will monitor client tcp close
@@ -97,7 +98,8 @@ handle_data(ServerRef, SessionsRef, TableDateRef, Sock, SocketMode, ListenPort, 
 		ws_loop = CustomOpts#custom_opts.ws_loop,
 		ws_autoexit = CustomOpts#custom_opts.ws_autoexit,
 		ws_versions = CustomOpts#custom_opts.ws_versions,
-		access_log = CustomOpts#custom_opts.access_log
+		access_log = CustomOpts#custom_opts.access_log,
+		external_ssl = CustomOpts#custom_opts.external_ssl
 	},
 	Req = #req{socket = Sock, socket_mode = SocketMode, peer_addr = PeerAddr, peer_port = PeerPort, peer_cert = PeerCert},
 	% enter loop
@@ -229,7 +231,7 @@ headers(#c{recv_timeout = RecvTimeout, ws_loop = WsLoop} = C, #req{socket = Sock
 					end;
 				{true, Vsn} ->
 					?LOG_DEBUG("websocket request received", []),
-					misultin_websocket:connect(C#c.server_ref, Req#req{headers = Headers}, #ws{vsn = Vsn, socket = Sock, socket_mode = SocketMode, peer_addr = Req#req.peer_addr, peer_port = Req#req.peer_port, path = Path, ws_autoexit = C#c.ws_autoexit}, WsLoop)
+					misultin_websocket:connect(C#c.server_ref, Req#req{headers = Headers, external_ssl = C#c.external_ssl}, #ws{vsn = Vsn, socket = Sock, socket_mode = SocketMode, peer_addr = Req#req.peer_addr, peer_port = Req#req.peer_port, path = Path, ws_autoexit = C#c.ws_autoexit}, WsLoop)
 			end;
 		{SocketMode, Sock, _Other} ->
 			?LOG_WARNING("tcp error treating headers: ~p, send bad request error back", [_Other]),

--- a/src/misultin_websocket_draft-hixie-68.erl
+++ b/src/misultin_websocket_draft-hixie-68.erl
@@ -66,11 +66,12 @@ check_websocket(Headers) ->
 % Description: Callback to build handshake data.
 % ----------------------------------------------------------------------------------------------------------
 -spec handshake(Req::#req{}, Headers::http_headers(), {Path::string(), Origin::string(), Host::string()}) -> iolist().
-handshake(#req{socket_mode = SocketMode} = _Req, _Headers, {Path, Origin, Host}) ->
+handshake(#req{socket_mode = SocketMode, external_ssl = ExternalSsl} = _Req, _Headers, {Path, Origin, Host}) ->
 	% prepare handhsake response
 	WsMode = case SocketMode of
 		ssl -> "wss";
-		_ -> "ws"
+		http when ExternalSsl =:= true  -> "wss"; % behind stunnel or similar, client is using ssl
+		http when ExternalSsl =:= false -> "ws"
 	end,
 	["HTTP/1.1 101 Web Socket Protocol Handshake\r\n",
 		"Upgrade: WebSocket\r\n",

--- a/src/misultin_websocket_draft-hixie-76.erl
+++ b/src/misultin_websocket_draft-hixie-76.erl
@@ -69,7 +69,7 @@ check_websocket(Headers) ->
 % Description: Callback to build handshake data.
 % ----------------------------------------------------------------------------------------------------------
 -spec handshake(Req::#req{}, Headers::http_headers(), {Path::string(), Origin::string(), Host::string()}) -> iolist().
-handshake(#req{socket = Sock, socket_mode = SocketMode}, Headers, {Path, Origin, Host}) ->
+handshake(#req{socket = Sock, socket_mode = SocketMode, external_ssl = ExternalSsl}, Headers, {Path, Origin, Host}) ->
 	% build data
 	Key1 = misultin_utility:header_get_value('Sec-WebSocket-Key1', Headers),
 	Key2 = misultin_utility:header_get_value('Sec-WebSocket-Key2', Headers),
@@ -88,7 +88,8 @@ handshake(#req{socket = Sock, socket_mode = SocketMode}, Headers, {Path, Origin,
 	% prepare handhsake response
 	WsMode = case SocketMode of
 		ssl -> "wss";
-		_ -> "ws"
+		http when ExternalSsl =:= true  -> "wss"; % behind stunnel or similar, client is using ssl
+		http when ExternalSsl =:= false -> "ws"
 	end,
 	% build challenge
 	Ikey1 = [D || D <- Key1, $0 =< D, D =< $9],


### PR DESCRIPTION
when misultin is deployed in http mode, behind an ssl-stripping proxy such as
stunnel, it needs to know, in order to respond to some websocket handshakes
correctly, choosing wss:// over ws:// (-hixie-76, -hixie-68)
