### PR TITLE
Support PROXY protocol from stunnel etc

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -68,6 +68,17 @@ DOCUMENTATION
 
 API Documentation is available online on the Misultin's wiki: https://github.com/ostinelli/misultin/wiki
 
+SSL NOTES
+==========================================================================================================
+If you are running misultin behind an SSL terminator such as stunnel or stud, then set 
+ {ws_force_ssl, true} 
+so that websocket handshakes work.
+
+If you are using stunnel to terminate, you can also set
+ {proxy_protocol, true}
+to make misultin expect a PROXY.. line as per http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt
+Newer versions of stunnel support this with the "protocol = proxy" config option.
+
 
 CHANGELOG
 ==========================================================================================================

--- a/examples/misultin_proxy_protocol.erl
+++ b/examples/misultin_proxy_protocol.erl
@@ -1,0 +1,49 @@
+% ==========================================================================================================
+% MISULTIN - Example: Proxy protocol
+%
+% >-|-|-(°>
+% 
+% Copyright (C) 2011, Roberto Ostinelli <roberto@ostinelli.net>
+% All rights reserved.
+%
+% BSD License
+% 
+% Redistribution and use in source and binary forms, with or without modification, are permitted provided
+% that the following conditions are met:
+%
+%  * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+%    following disclaimer.
+%  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and
+%    the following disclaimer in the documentation and/or other materials provided with the distribution.
+%  * Neither the name of the authors nor the names of its contributors may be used to endorse or promote
+%    products derived from this software without specific prior written permission.
+%
+% THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+% WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+% PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+% ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+% TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+% HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+% NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+% POSSIBILITY OF SUCH DAMAGE.
+% ==========================================================================================================
+%
+% This test assumes you are accessing misultin via something that supports the
+% haproxy proxy protocol, such as recent versions of stunnel.
+% see: http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt
+-module(misultin_proxy_protocol).
+-export([start/1, stop/0]).
+
+% start misultin http server
+start(Port) ->
+	misultin:start_link([{proxy_protocol, true}, {port, Port}, {loop, fun(Req) -> handle_http(Req) end}]).
+
+% stop misultin
+stop() ->
+	misultin:stop().
+
+% callback on request received
+handle_http(Req) ->
+    {A,B,C,D} = Req:get(peer_addr),
+    Msg = io_lib:format("Hello ~B.~B.~B.~B", [A,B,C,D]),
+	Req:ok(Msg).

--- a/include/misultin.hrl
+++ b/include/misultin.hrl
@@ -151,7 +151,9 @@
 	ws_autoexit			= true :: boolean(),							% shoud the ws process be automatically killed?
 	ws_versions			= undefined :: [websocket_version()],			% list of supported ws versions
 	access_log			= undefined :: undefined | function(),			% access log function
-	ws_force_ssl		= false :: boolean()							% if we are deployed behind stunnel, or other ssl proxy
+	ws_force_ssl		= false :: boolean(),							% if we are deployed behind stunnel, or other ssl proxy
+	proxy_protocol		= false :: boolean()							% upstream proxy is sending us http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt
+
 }).
 
 % Request

--- a/src/misultin.erl
+++ b/src/misultin.erl
@@ -106,6 +106,7 @@ init([Options]) ->
 		{max_connections, 4096, fun is_non_neg_integer/1, invalid_max_connections_option},
 		{ssl, false, fun check_ssl_options/1, invalid_ssl_options},
 		{ws_force_ssl, false, fun is_boolean/1, invalid_ssl_external},
+		{proxy_protocol, false, fun is_boolean/1, invalid_proxy_protocol},
 		{recbuf, default, fun check_recbuf/1, recbuf_not_integer},
 		% misultin
 		{post_max_size, 4*1024*1024, fun is_non_neg_integer/1, invalid_post_max_size_option},		% defaults to 4 MB
@@ -132,6 +133,7 @@ init([Options]) ->
 			MaxConnections = proplists:get_value(max_connections, OptionsVerified),
 			SslOptions0 = proplists:get_value(ssl, OptionsVerified),
 			WsForceSsl = proplists:get_value(ws_force_ssl, OptionsVerified),
+			ProxyProtocol = proplists:get_value(proxy_protocol, OptionsVerified),
 			% misultin options
 			PostMaxSize = proplists:get_value(post_max_size, OptionsVerified),
 			GetUrlMaxSize = proplists:get_value(get_url_max_size, OptionsVerified),
@@ -197,7 +199,8 @@ init([Options]) ->
 						ws_autoexit = WsAutoExit,
 						ws_versions = WsVersions,
 						access_log = AccessLogFun,
-						ws_force_ssl = WsForceSsl
+						ws_force_ssl = WsForceSsl,
+						proxy_protocol = ProxyProtocol
 					},
 					% define misultin_server supervisor specs
 					ServerSpec = {server, {misultin_server, start_link, [{MaxConnections}]}, permanent, 60000, worker, [misultin_server]},


### PR DESCRIPTION
Adds a {proxy_protocol,true} option, causing misultin acceptors to read the
first line of a new socket connection for the PROXY line, as per:
 http://haproxy.1wt.eu/download/1.5/doc/proxy-protocol.txt

This allows misultin to see the correct client IP, when behind stunnel - otherwise you just see the IP of the stunnel machine rather than the client IP.

HAProxy are standardizing on this now, so should make it easier to play nicely with haproxy, stunnel, stud and others.

Used in conjunction with the ws_force_ssl option I added, misultin works properly behind stunnel, websockets and all.
