### PR TITLE
Added support for HTTP 422 status

### DIFF
--- a/src/misultin_utility.erl
+++ b/src/misultin_utility.erl
@@ -140,6 +140,8 @@ get_http_status_message(416) ->
 	"416 Requested Range Not Satisfiable";
 get_http_status_message(417) ->
 	"417 Expectation Failed";
+get_http_status_message(422) ->
+    "422 Unprocessable Entity";
 get_http_status_message(502) ->
 	"502 Bad Gateway";
 get_http_status_message(503) ->


### PR DESCRIPTION
If I respond with a 422, Misultin does not know how to throw this error back and I actually get a 200 instead.  If you debug with Firebug, you actually see Misultin responding with two status codes: 200 422

Req:respond(422, [], "some validation error").

The response Misultin sends is:

Date: Sat, 26 Nov 2011 10:04:31 GMT
Server: misultin/0.9-dev
Connection: Close
Content-Length: 21

some validation error
