### PR TITLE
fixed get_peer function in misultin_utility

### DIFF
--- a/src/misultin_utility.erl
+++ b/src/misultin_utility.erl
@@ -533,9 +533,9 @@ get_peer(Headers, ConnectionPeerAddr) ->
 		_ ->
 			case inet_parse:address(Host) of
 				{error, _Reason} ->
-					ConnectionPeerAddr;
+					{ok, ConnectionPeerAddr};
 				{ok, IpTuple} ->
-					IpTuple
+					{ok, IpTuple}
 			end
 	end.
 


### PR DESCRIPTION
Previously function could return IpTuple instead of {ok, IpTuple} in case when X-Forwarded-For header was present which conficted in other modules (in example case clause in 628 line in misultin_http)
